### PR TITLE
Add early support for 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,22 +34,22 @@ Now that you have a working development environment, why not try the [Commercial
 
 ## Alternative toppings
 
-To install specific versions of Fabric, set a `FABRIC_VERSION` environment variable before running `vagrant up`. 
+To install specific versions of Fabric, set a `HLF_VERSION` environment variable before running `vagrant up`. 
 
 For example, to install the previous version of Fabric use:
 
 ```
-FABRIC_VERSION=1.2 vagrant up
+HLF_VERSION=1.2 vagrant up
 ```
 
 Or on Windows:
 
 ```
-set FABRIC_VERSION=1.2
+set HLF_VERSION=1.2
 vagrant up
 ```
 
-Supported `FABRIC_VERSION` values:
+Supported `HLF_VERSION` values:
 
 - Specific `1.2`, `1.3`, or `1.4` version numbers
 

--- a/provision-root.sh
+++ b/provision-root.sh
@@ -9,13 +9,13 @@ else
   HLF_VERSION=$1
 fi
 
-if [ ${HLF_VERSION:0:4} = '1.2.' -o ${HLF_VERSION:0:4} = '1.3.' -o ${HLF_VERSION:0:4} = '1.4.' ]; then
+if [ ${HLF_VERSION:0:4} = '1.2.' -o ${HLF_VERSION:0:4} = '1.3.' -o ${HLF_VERSION:0:4} = '1.4.' -o ${HLF_VERSION:0:4} = '2.0.' ]; then
   export GO_VERSION=1.10.4
 elif [ ${HLF_VERSION:0:4} = '1.1.' ]; then
   export GO_VERSION=1.9.7
 else
   >&2 echo "Unexpected HLF_VERSION ${HLF_VERSION}"
-  >&2 echo "HLF_VERSION must be a 1.1.x, 1.2.x, 1.3.x, or 1.4.x version"
+  >&2 echo "HLF_VERSION must be a 1.1.x, 1.2.x, 1.3.x, 1.4.x, or 2.0.x version"
   exit 1
 fi
 

--- a/provision-user.sh
+++ b/provision-user.sh
@@ -9,6 +9,15 @@ else
   HLF_VERSION=$1
 fi
 
+CA_VERSION=$HLF_VERSION
+THIRDPARTY_IMAGE_VERSION=0.4.15
+
+if [ ${HLF_VERSION:0:4} = '2.0.' ]; then
+  SAMPLE_BRANCH=master
+else
+  SAMPLE_BRANCH=v${HLF_VERSION}
+fi
+
 # Install NVM
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] || curl --silent --show-error -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash
@@ -31,7 +40,7 @@ npm ls -g hlf-cli >/dev/null 2>&1 || npm install -g hlf-cli
 if [ ! -d "$HOME/fabric" ]; then
   mkdir -p "$HOME/fabric"
   pushd "$HOME/fabric"
-  sg docker "curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/master/scripts/bootstrap.sh | bash -s -- $HLF_VERSION -s"
+  sg docker "curl -sSL https://raw.githubusercontent.com/hyperledger/fabric/be235fd3a236f792a525353d9f9586c8b0d4a61a/scripts/bootstrap.sh | bash -s -- $HLF_VERSION $CA_VERSION $THIRDPARTY_IMAGE_VERSION -s"
   popd
 fi
 
@@ -52,7 +61,7 @@ fi
 if [ ! -d "$HOME/go/src/github.com/hyperledger/fabric-samples" ]; then
   mkdir -p "$HOME/go/src/github.com/hyperledger"
   pushd "$HOME/go/src/github.com/hyperledger"
-  git clone --branch v${HLF_VERSION} --depth 1 https://github.com/hyperledger/fabric-samples.git
+  git clone --branch ${SAMPLE_BRANCH} --depth 1 https://github.com/hyperledger/fabric-samples.git
   popd
 fi
 


### PR DESCRIPTION
Also fixes issue caused by https://jira.hyperledger.org/browse/FAB-15316 by downloading a tagged version of Fabric's bootstrap.sh

Signed-off-by: James Taylor <jamest@uk.ibm.com>